### PR TITLE
Provide Fixed Static Samplers

### DIFF
--- a/Cumulus/src/Core/Pass.cpp
+++ b/Cumulus/src/Core/Pass.cpp
@@ -90,22 +90,7 @@ bool Pass::GenerateRootSignature()
 
     for (const auto& sampler : Samplers)
     {
-        D3D12_STATIC_SAMPLER_DESC samplerDesc = {};
-        samplerDesc.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
-        samplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        samplerDesc.MipLODBias = 0;
-        samplerDesc.MaxAnisotropy = 16;
-        samplerDesc.ComparisonFunc = D3D12_COMPARISON_FUNC_LESS_EQUAL;
-        samplerDesc.BorderColor = D3D12_STATIC_BORDER_COLOR_OPAQUE_WHITE;
-        samplerDesc.MinLOD = 0.0f;
-        samplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
-        samplerDesc.ShaderRegister = sampler.BindPoint;
-        samplerDesc.RegisterSpace = sampler.Space;
-        samplerDesc.ShaderVisibility = sampler.Visibility;
-
-        builder.AddStaticSampler(samplerDesc);
+        builder.AddStaticSampler(sampler.BindPoint, sampler.Space);
     }
 
     return builder.Build(pDevice, mpRootSignature.GetAddressOf());

--- a/Cumulus/src/Core/RootSignatureBuilder.h
+++ b/Cumulus/src/Core/RootSignatureBuilder.h
@@ -19,7 +19,7 @@ public:
     void AddShaderResourceView(UINT shaderRegister, UINT space, D3D12_SHADER_VISIBILITY visibility);
     void AddUnorderedAccessView(UINT shaderRegister, UINT space, D3D12_SHADER_VISIBILITY visibility);
     void AddDescriptorTable(const D3D12_DESCRIPTOR_RANGE* ranges, UINT numRanges, D3D12_SHADER_VISIBILITY visibility);
-    void AddStaticSampler(const D3D12_STATIC_SAMPLER_DESC& sampler);
+    void AddStaticSampler(UINT shaderRegister, UINT registerSpace);
 
     bool Build(ID3D12Device* pDevice, ID3D12RootSignature** ppRootSig);
 


### PR DESCRIPTION
We define 6 static samplers:
pointWrap = 0,
pointClamp = 1,
linearWrap = 2,
linearClamp =3,
anisotropicWrap = 4,
anisotropicClamp =5

The indices are fixed and everytime a shader asks for one, that one will be provided by the engine.

Note: Each sampler is fetched by _index_ and **not** name, so ensure that your ```SamplerState sampler : register(s*)``` matches the sampler type you want.